### PR TITLE
fix: failing refresh

### DIFF
--- a/oauth-interceptor.js
+++ b/oauth-interceptor.js
@@ -26,10 +26,10 @@ function getTokenState (token) {
 }
 
 let _requestingRefresh
-function callRefreshToken (refreshHost, refreshToken, clientId) {
+function callRefreshToken (refreshEndpoint, refreshToken, clientId) {
   if (_requestingRefresh) return _requestingRefresh
 
-  _requestingRefresh = refreshAccessToken(refreshHost, refreshToken, clientId)
+  _requestingRefresh = refreshAccessToken({ refreshEndpoint, refreshToken, clientId })
   _requestingRefresh.catch(() => _requestingRefresh = null)
   _requestingRefresh.then((result) => {
     _requestingRefresh = null

--- a/tests/interceptor.test.js
+++ b/tests/interceptor.test.js
@@ -542,8 +542,9 @@ test('optimistic refresh', async (t) => {
     let body = ''
     req.on('data', chunk => body += chunk)
     req.on('end', () => {
-      const { grant_type } = JSON.parse(body)
+      const { grant_type, refresh_token } = JSON.parse(body)
       assert.strictEqual(grant_type, 'refresh_token')
+      assert.ok(refresh_token)
     })
 
     accessToken = createToken({ name: 'access' }, { expiresIn: '1d' })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -15,8 +15,8 @@ test('refreshAccessToken() - success', async (t) => {
     method: 'POST',
     path: '/token',
     body: body => {
-      const { token, grant_type, client_id } = JSON.parse(body)
-      assert.strictEqual(token, 'refresh-token')
+      const { refresh_token, grant_type, client_id } = JSON.parse(body)
+      assert.strictEqual(refresh_token, 'refresh-token')
       assert.strictEqual(grant_type, 'refresh_token')
       assert.strictEqual(client_id, 'client-id')
       return true
@@ -25,6 +25,10 @@ test('refreshAccessToken() - success', async (t) => {
     access_token: 'new-access-token'
   })
 
-  const accessToken = await refreshAccessToken('https://example.com', 'client-id', 'refresh-token')
+  const accessToken = await refreshAccessToken({
+    refreshEndpoint: 'https://example.com',
+    clientId: 'client-id',
+    refreshToken: 'refresh-token'
+  })
   assert.strictEqual(accessToken, 'new-access-token')
 })

--- a/utils.js
+++ b/utils.js
@@ -2,14 +2,14 @@
 
 const { request } = require('undici')
 
-async function refreshAccessToken (refreshEndpoint, clientId, refreshToken) {
+async function refreshAccessToken ({ refreshEndpoint, refreshToken, clientId }) {
   const { statusCode, body } = await request(`${refreshEndpoint}/token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      token: refreshToken,
+      refresh_token: refreshToken,
       grant_type: 'refresh_token',
       client_id: clientId
     })


### PR DESCRIPTION
Two problems:

1. sending the wrong payload to an oauth refresh endpoint (`token` instead of `refresh_token`)
2. Incorrect order of function params