### PR TITLE
fix: allow idp and resource to have the same origin

### DIFF
--- a/oidc-interceptor.js
+++ b/oidc-interceptor.js
@@ -69,7 +69,7 @@ function createOidcInterceptor (options) {
 
   return dispatch => {
     return function Intercept (opts, handler) {
-      if (!opts.oauthRetry && !urls.includes(opts.origin)) {
+      if ((!opts.oauthRetry && !urls.includes(opts.origin)) || idpTokenUrl === `${opts.origin}${opts.path}`) {
         // do not attempt intercept
         return dispatch(opts, handler)
       }


### PR DESCRIPTION
Requests to the idp token server url should not be intercepted.