### PR TITLE
feat: custom ttl with oidc expiry as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,32 @@ const dispatcher = new Agent().compose(createOidcInterceptor({
 }))
 ```
 
+### Custom TTL
+If you want to customize the TTL for tokens based on the `expiresIn` value from the OIDC response, you can provide a custom function.
+
+Example:
+```js
+const Redis = require('ioredis')
+const { Agent } = require('undici')
+const { createOidcInterceptor } = require('undici-oidc-interceptor')
+
+const redisClient = new Redis()
+
+const dispatcher = new Agent().compose(createOidcInterceptor({
+  ...options,
+  tokenStore: {
+    name: 'test-cache',
+    ttl: (tokenPayload) => tokenPayload.expiresIn * 80 / 100, // Sets token TTL to 80% of the OIDC expiry time
+    storage: { 
+      type: 'redis', 
+      options: { 
+        client: redisClient 
+      } 
+    }
+  }
+}))
+```
+
 ## License
 
 MIT

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -16,6 +16,11 @@ class TokenStore {
 
     if (name) this.#name = name
 
+    // Set default TTL as 80% of the OIDC token lifetime.
+    if(!cacheOptions.ttl) {
+      cacheOptions.ttl = (tokenPayload) => tokenPayload.expiresIn ? Math.round(tokenPayload.expiresIn * 80 / 100) : 0
+    }
+
     this.#store = createCache(cacheOptions)
     this.#store.define(this.#name, {
       serialize
@@ -23,7 +28,7 @@ class TokenStore {
 
     this.token = this.token.bind(this)
   }
-  
+
   async token (options) {
     return this.#store[this.#name](options)
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,7 +63,7 @@ async function refreshAccessToken ({ idpTokenUrl, refreshToken, clientId, client
     throw new Error(`Failed to refresh access token - status code ${statusCode} - ${JSON.stringify(parsed)}`)
   }
 
-  const { access_token: accessToken, token_type: tokenType } = await body.json()
+  const { access_token: accessToken, token_type: tokenType, expires_in: expiresIn } = await body.json()
 
   if (!accessToken) {
     throw new Error('Failed to refresh access token - no access_token in response')
@@ -74,7 +74,10 @@ async function refreshAccessToken ({ idpTokenUrl, refreshToken, clientId, client
     throw new Error(`Failed to refresh access token - unexpected token_type ${tokenType}`)
   }
 
-  return accessToken
+  return {
+    accessToken,
+    expiresIn
+  }
 }
 
 module.exports = {

--- a/oidc-interceptor.js
+++ b/oidc-interceptor.js
@@ -73,7 +73,8 @@ function createOidcInterceptor (options) {
     }
 
     _requestingRefresh = store.token(tokenOptions)
-      .then(async token => {
+      .then(async (tokenPayload) => {
+        const { accessToken: token } = tokenPayload
  
         // Check again the token state in case it expired after fetch 
         // If expired, clear the cache and fetch a new one
@@ -85,7 +86,7 @@ function createOidcInterceptor (options) {
             if(!refreshTokenPromises.has(optionsKey)) {
               const promise = (async () => {
                 await store.clear(tokenOptions)
-                return await store.token(tokenOptions)
+                return await store.token(tokenOptions).then((tokenPayload) => tokenPayload.accessToken)
               })()
               refreshTokenPromises.set(optionsKey, promise)
               promise.finally(() => refreshTokenPromises.delete(optionsKey))

--- a/oidc-interceptor.js
+++ b/oidc-interceptor.js
@@ -37,7 +37,6 @@ function createOidcInterceptor (options) {
     resource,
     audience,
     tokenStore = {
-      ttl: 0,
       storage: { type: 'memory' }
     }
   } = options
@@ -75,15 +74,15 @@ function createOidcInterceptor (options) {
     _requestingRefresh = store.token(tokenOptions)
       .then(async (tokenPayload) => {
         const { accessToken: token } = tokenPayload
- 
-        // Check again the token state in case it expired after fetch 
+
+        // Check again the token state in case it expired after fetch
         // If expired, clear the cache and fetch a new one
         // If near expiration, clear the cache but return current token
         // If valid, return current token
         switch (getTokenState(token)) {
           case TOKEN_STATE.EXPIRED:
             const optionsKey = stringify(options)
-            if(!refreshTokenPromises.has(optionsKey)) {
+            if (!refreshTokenPromises.has(optionsKey)) {
               const promise = (async () => {
                 await store.clear(tokenOptions)
                 return await store.token(tokenOptions).then((tokenPayload) => tokenPayload.accessToken)
@@ -112,7 +111,7 @@ function createOidcInterceptor (options) {
         // do not attempt intercept
         return dispatch(opts, handler)
       }
-
+      
       if (opts.oauthRetry) {
         return callRefreshToken()
           .catch(err => {

--- a/tests/interceptor-cache-store.test.js
+++ b/tests/interceptor-cache-store.test.js
@@ -101,7 +101,7 @@ describe('interceptor cache store', async () => {
 
     const { statusCode } = await request(`http://localhost:${mainServer.address().port}`, { dispatcher })
     assert.strictEqual(statusCode, 200)
-    assert.strictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), accessToken)
+    assert.deepStrictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), {accessToken})
   })
 
   test('regenerate access token as the store cache is expiried', async (t) => {
@@ -146,7 +146,7 @@ describe('interceptor cache store', async () => {
     const oldAccessToken = accessToken
 
     assert.strictEqual(statusCode, 200)
-    assert.strictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), oldAccessToken)
+    assert.deepStrictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), {accessToken: oldAccessToken})
 
     await sleep(1000)
     assert.strictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), null)
@@ -155,7 +155,7 @@ describe('interceptor cache store', async () => {
     const newAccessToken = accessToken
 
     assert.strictEqual(statusCode2, 200)
-    assert.strictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), newAccessToken)
+    assert.deepStrictEqual(JSON.parse(await redisClient.get('test-cache~client-id')), {accessToken: newAccessToken})
     assert.notStrictEqual(oldAccessToken, newAccessToken)
   })
 

--- a/tests/oidc-provider.test.js
+++ b/tests/oidc-provider.test.js
@@ -11,9 +11,9 @@ const { createOidcInterceptor } = require('../')
 
 test('interceptor works with oidc-provider', async (t) => {
   const jwks = buildGetJwks({
-    jwksPath: '/jwks',
+    jwksPath: '/jwks'
   })
-  const provider = await testProvider(test, { port: 3000 });
+  const provider = await testProvider(test, { port: 3000 })
   const expectedIssuer = `http://localhost:${provider.address().port}`
   const idp = `${expectedIssuer}/`
   const idpTokenUrl = `${idp}token`
@@ -36,7 +36,7 @@ test('interceptor works with oidc-provider', async (t) => {
 
   const targetUrl = `http://localhost:${mainServer.address().port}`
 
-  const dispatcher = new Agent().compose(createOidcInterceptor({ 
+  const dispatcher = new Agent().compose(createOidcInterceptor({
     clientId: 'foo',
     clientSecret: 'bar',
     idpTokenUrl,
@@ -46,5 +46,5 @@ test('interceptor works with oidc-provider', async (t) => {
   const response = await request(targetUrl, {
     dispatcher
   })
-  assert.strictEqual(response.statusCode, 200);
+  assert.strictEqual(response.statusCode, 200)
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -22,7 +22,8 @@ test('refreshAccessToken() - success', async (t) => {
       return true
     }
   }).reply(200, {
-    access_token: 'new-access-token'
+    access_token: 'new-access-token',
+    expires_in: 300
   })
 
   const accessToken = await refreshAccessToken({
@@ -30,7 +31,7 @@ test('refreshAccessToken() - success', async (t) => {
     clientId: 'client-id',
     refreshToken: 'refresh-token'
   })
-  assert.strictEqual(accessToken, 'new-access-token')
+  assert.deepStrictEqual(accessToken, { accessToken: 'new-access-token', expiresIn: 300 })
 })
 
 test('refreshAccessToken() - success / json', async (t) => {
@@ -55,5 +56,5 @@ test('refreshAccessToken() - success / json', async (t) => {
     refreshToken: 'refresh-token',
     contentType: 'json'
   })
-  assert.strictEqual(accessToken, 'new-access-token')
+  assert.deepStrictEqual(accessToken, { accessToken: 'new-access-token', expiresIn: undefined })
 })


### PR DESCRIPTION
## Summary

- Improves flexibility for developers to align cache behavior with OIDC token lifetimes.
- Useful in scenarios where early expiration is preferred to handle clock drift or reduce risk of using

## Example Usage
```js
const Redis = require('ioredis')
const { Agent } = require('undici')
const { createOidcInterceptor } = require('undici-oidc-interceptor')

const redisClient = new Redis()

const dispatcher = new Agent().compose(createOidcInterceptor({
  ...options,
  tokenStore: {
    name: 'test-cache',
    ttl: (tokenPayload) => tokenPayload.expiresIn * 80 / 100, // Sets token TTL to 80% of the OIDC expiry time
    storage: {
      type: 'redis',
      options: {
        client: redisClient
      }
    }
  }
}))

```

This ensures tokens expire slightly before the actual OIDC expiry, helping avoid edge cases where a token may expire during a request.