### PR TITLE
Do not use pnpm cache for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
       - name: Restore cached dependencies
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
Ref: https://github.com/platformatic/platformatic/pull/4784

Removes pnpm dependency caching from the release publishing workflow to avoid reusing a potentially poisoned cache when publishing packages.