### PR TITLE
feat: idpDispatcher option for the interceptor’s token requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ await request('https://api.example.com/admin', {
 })
 ```
 
+## IdP dispatcher
+
+Token requests to `idpTokenUrl` go through the global undici dispatcher by
+default. Pass `idpDispatcher` to route them through your own — for example
+an `Agent` with `allowH2: true` when the IdP sits behind an HTTP/2-only
+front (AWS ALBs answer HTTP/1 requests to an HTTP/2 target group with a
+464):
+
+```js
+const idpAgent = new Agent({ allowH2: true })
+const agent = new Agent({ allowH2: true }).compose(createOidcInterceptor({
+  clientId: 'FILLME',
+  clientSecret: 'FILLME',
+  idpTokenUrl: 'https://your-idp.com/token',
+  idpDispatcher: idpAgent,
+  urls: ['https://api.example.com']
+}))
+```
+
 ## Token store
 
 This interceptor uses the [async-cache-dedupe](https://github.com/mcollina/async-cache-dedupe) package to cache access tokens. This improves efficiency by enabling token reuse across processes or instances and avoids unnecessary token refresh requests.

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -11,6 +11,7 @@ class TokenStore {
     const {
       name,
       serialize = null,
+      dispatcher,
       ...cacheOptions
     } = options
 
@@ -22,9 +23,11 @@ class TokenStore {
     }
 
     this.#store = createCache(cacheOptions)
+    // The dispatcher is captured in the resolver rather than threaded through
+    // the token options, so it never becomes part of the cache key.
     this.#store.define(this.#name, {
       serialize
-    }, refreshAccessToken)
+    }, (tokenOptions) => refreshAccessToken({ ...tokenOptions, dispatcher }))
 
     this.token = this.token.bind(this)
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const { request } = require('undici')
 
-async function refreshAccessToken ({ idpTokenUrl, refreshToken, clientId, clientSecret, contentType, scope, resource, audience }) {
+async function refreshAccessToken ({ idpTokenUrl, refreshToken, clientId, clientSecret, contentType, scope, resource, audience, dispatcher }) {
   let objToSend = null
 
   if (refreshToken) {
@@ -55,7 +55,8 @@ async function refreshAccessToken ({ idpTokenUrl, refreshToken, clientId, client
       Accept: 'application/json; charset=utf-8',
       'Content-Type': contentType
     },
-    body: bodyToSend
+    body: bodyToSend,
+    dispatcher
   })
 
   if (statusCode !== 200) {

--- a/oidc-interceptor.js
+++ b/oidc-interceptor.js
@@ -26,7 +26,7 @@ function getTokenState (token) {
 }
 
 function createOidcInterceptor (options) {
-  const { refreshToken, clientSecret, contentType, shouldAuthenticate } = options
+  const { refreshToken, clientSecret, contentType, shouldAuthenticate, idpDispatcher } = options
   let {
     accessToken,
     retryOnStatusCodes,
@@ -44,7 +44,7 @@ function createOidcInterceptor (options) {
   retryOnStatusCodes = retryOnStatusCodes || [401]
   urls = urls || []
 
-  const store = new TokenStore(tokenStore)
+  const store = new TokenStore({ dispatcher: idpDispatcher, ...tokenStore })
 
   // TODO: if there is a refresh_token, we might not need the idpTokenUrl and use the standard
   // discovery mechanism. See

--- a/tests/interceptor.test.js
+++ b/tests/interceptor.test.js
@@ -588,3 +588,49 @@ test('do not intercept if url not passed in urls option', async (t) => {
   const { statusCode } = await request(`http://127.0.0.1:${server.address().port}`, { dispatcher })
   assert.strictEqual(statusCode, 200)
 })
+
+test('refresh the token through idpDispatcher when provided', async (t) => {
+  let accessToken = ''
+  const mainServer = http.createServer((req, res) => {
+    assert.strictEqual(req.headers.authorization, `Bearer ${accessToken}`)
+    res.writeHead(200)
+    res.end()
+  })
+  mainServer.listen(0)
+
+  const tokenServer = http.createServer((req, res) => {
+    assert.strictEqual(req.method, 'POST')
+    assert.strictEqual(req.url, '/token')
+
+    accessToken = createToken({ name: 'access' }, { expiresIn: '1d' })
+    res.writeHead(200)
+    res.end(JSON.stringify({ access_token: accessToken }))
+  })
+  tokenServer.listen(0)
+
+  t.after(() => {
+    mainServer.close()
+    tokenServer.close()
+  })
+
+  const targetUrl = `http://localhost:${mainServer.address().port}`
+  const idpTokenUrl = `http://localhost:${tokenServer.address().port}/token`
+
+  const routed = []
+  const idpDispatcher = new Agent().compose(dispatch => (opts, handler) => {
+    routed.push(`${opts.origin}${opts.path}`)
+    return dispatch(opts, handler)
+  })
+
+  const dispatcher = new Agent().compose(createOidcInterceptor({
+    urls: [targetUrl],
+    idpTokenUrl,
+    idpDispatcher,
+    clientId: 'client-id',
+    clientSecret: 'client-secret'
+  }))
+
+  const { statusCode } = await request(targetUrl, { dispatcher })
+  assert.strictEqual(statusCode, 200)
+  assert.deepStrictEqual(routed, [idpTokenUrl])
+})

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -58,3 +58,25 @@ test('refreshAccessToken() - success / json', async (t) => {
   })
   assert.deepStrictEqual(accessToken, { accessToken: 'new-access-token', expiresIn: undefined })
 })
+
+test('refreshAccessToken() - uses the provided dispatcher', async (t) => {
+  // The global dispatcher (net-disabled, no interceptor for this origin)
+  // would fail this request — succeeding proves the dispatcher option won.
+  const dispatcherAgent = new MockAgent()
+  dispatcherAgent.disableNetConnect()
+  dispatcherAgent.get('https://dispatcher-only.example.com').intercept({
+    method: 'POST',
+    path: '/token'
+  }).reply(200, {
+    access_token: 'new-access-token',
+    expires_in: 300
+  })
+
+  const accessToken = await refreshAccessToken({
+    idpTokenUrl: 'https://dispatcher-only.example.com/token',
+    clientId: 'client-id',
+    refreshToken: 'refresh-token',
+    dispatcher: dispatcherAgent
+  })
+  assert.deepStrictEqual(accessToken, { accessToken: 'new-access-token', expiresIn: 300 })
+})


### PR DESCRIPTION
## Motivation

The interceptor's token requests to `idpTokenUrl` (`lib/utils.js` → `request()`) go through undici's **global dispatcher**, which only speaks HTTP/1.1. When the IdP sits behind an HTTP/2-only front, every token refresh fails even though the composed dispatcher itself negotiates HTTP/2 via `allowH2` — an AWS ALB answers HTTP/1 requests to an HTTP/2 target group with a `464`. We hit this with a CLI authenticating against [Zitadel](https://zitadel.com) behind an ALB: the interceptor injected tokens fine, but its own refresh got `464 Incompatible protocol. Use HTTP/2.`

## Change

A new `idpDispatcher` option routes the interceptor's token requests through a caller-provided dispatcher:

```js
const idpAgent = new Agent({ allowH2: true })
const agent = new Agent({ allowH2: true }).compose(createOidcInterceptor({
  clientId: '...',
  clientSecret: '...',
  idpTokenUrl: 'https://your-idp.com/token',
  idpDispatcher: idpAgent,
  urls: ['https://api.example.com']
}))
```

Design note: the `TokenStore` captures the dispatcher in the cache resolver instead of threading it through the token options, so it never becomes part of the async-cache-dedupe cache key. Default behavior (no `idpDispatcher`) is unchanged — `request()` receives `dispatcher: undefined` and falls back to the global dispatcher.

## Testing

- `tests/utils.test.js`: `refreshAccessToken()` with a `dispatcher` succeeds against a net-disabled global `MockAgent` — proving the option is what carried the request.
- `tests/interceptor.test.js`: an interceptor with `idpDispatcher` (a recording `Agent`) refreshes through it and nothing else.
- Full suite green locally (including the redis-backed cache-store tests), lint clean.

We currently ship this as a pnpm patch in production; happy to adjust naming or approach.